### PR TITLE
Changing everything related to Quik to UP etc, setting the default ap…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,6 @@ buildscript {
     ext.rxkotlin_version = '2.1.0'
     ext.rx_preferences_version = '2.0.0-RC3'
     ext.timber_version = '4.5.1'
-
     ext.abiCodes = ['armeabi-v7a': 1, 'arm64-v8a': 2]
 
     repositories {

--- a/data/src/main/java/com/moez/QKSMS/manager/WidgetManagerImpl.kt
+++ b/data/src/main/java/com/moez/QKSMS/manager/WidgetManagerImpl.kt
@@ -33,7 +33,7 @@ class WidgetManagerImpl @Inject constructor(private val context: Context) : Widg
 
     override fun updateTheme() {
         val ids = AppWidgetManager.getInstance(context)
-                .getAppWidgetIds(ComponentName("dev.octoshrimpy.quik", "dev.octoshrimpy.quik.feature.widget.WidgetProvider"))
+                .getAppWidgetIds(ComponentName("com.unplugged.messages", "dev.octoshrimpy.quik.feature.widget.WidgetProvider"))
 
         val intent = Intent().putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, ids)
 

--- a/data/src/main/java/com/moez/QKSMS/service/HeadlessSmsSendService.kt
+++ b/data/src/main/java/com/moez/QKSMS/service/HeadlessSmsSendService.kt
@@ -32,6 +32,7 @@ class HeadlessSmsSendService : IntentService("HeadlessSmsSendService") {
     @Inject lateinit var conversationRepo: ConversationRepository
     @Inject lateinit var sendMessage: SendMessage
 
+    @Deprecated("Deprecated in Java")
     override fun onHandleIntent(intent: Intent?) {
         if (intent?.action != TelephonyManager.ACTION_RESPOND_VIA_MESSAGE) return
 

--- a/domain/src/main/java/com/moez/QKSMS/interactor/Interactor.kt
+++ b/domain/src/main/java/com/moez/QKSMS/interactor/Interactor.kt
@@ -47,5 +47,4 @@ abstract class Interactor<in Params> : Disposable {
     override fun isDisposed(): Boolean {
         return disposables.isDisposed
     }
-
 }

--- a/domain/src/main/java/com/moez/QKSMS/util/Preferences.kt
+++ b/domain/src/main/java/com/moez/QKSMS/util/Preferences.kt
@@ -100,7 +100,7 @@ class Preferences @Inject constructor(
     val nightEnd = rxPrefs.getString("nightEnd", "6:00")
     val black = rxPrefs.getBoolean("black", false)
     val autoColor = rxPrefs.getBoolean("autoColor", true)
-    val systemFont = rxPrefs.getBoolean("systemFont", false)
+    val systemFont = rxPrefs.getBoolean("systemFont", true)
     val textSize = rxPrefs.getInteger("textSize", TEXT_SIZE_NORMAL)
     val blockingManager = rxPrefs.getInteger("blockingManager", BLOCKING_MANAGER_QKSMS)
     val drop = rxPrefs.getBoolean("drop", false)
@@ -110,7 +110,7 @@ class Preferences @Inject constructor(
     val qkreply = rxPrefs.getBoolean("qkreply", Build.VERSION.SDK_INT < Build.VERSION_CODES.N)
     val qkreplyTapDismiss = rxPrefs.getBoolean("qkreplyTapDismiss", true)
     val sendDelay = rxPrefs.getInteger("sendDelay", SEND_DELAY_NONE)
-    val swipeRight = rxPrefs.getInteger("swipeRight", SWIPE_ACTION_ARCHIVE)
+    val swipeRight = rxPrefs.getInteger("swipeRight", SWIPE_ACTION_DELETE)
     val swipeLeft = rxPrefs.getInteger("swipeLeft", SWIPE_ACTION_ARCHIVE)
     val autoEmoji = rxPrefs.getBoolean("autoEmoji", true)
     val delivery = rxPrefs.getBoolean("delivery", false)
@@ -154,10 +154,10 @@ class Preferences @Inject constructor(
 
     fun theme(
         recipientId: Long = 0,
-        default: Int = rxPrefs.getInteger("theme", 0xFF0097A7.toInt()).get()
+        default: Int = rxPrefs.getInteger("theme", 0xFF00B7A7.toInt()).get()
     ): Preference<Int> {
         return when (recipientId) {
-            0L -> rxPrefs.getInteger("theme", 0xFF0097A7.toInt())
+            0L -> rxPrefs.getInteger("theme", 0xFF00B7A7.toInt())
             else -> rxPrefs.getInteger("theme_$recipientId", default)
         }
     }

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -27,34 +27,30 @@ android {
     flavorDimensions "analytics"
 
     defaultConfig {
-        applicationId 'dev.octoshrimpy.quik'
+        applicationId 'com.unplugged.messages'
         minSdkVersion 23
         targetSdkVersion 33
         versionCode 2225
         versionName '4.0.8'
-        setProperty("archivesBaseName", "QUIK-v${versionName}")
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-
-        setProperty("archivesBaseName", "QUIK-v${versionName}")
-        versionNameSuffix '-alpha'
     }
 
     signingConfigs {
-        release {
-            def keystoreProps = new Properties()
-            def keystorePropsFile = rootProject.file('./.gradle/.gradlerc')
-            storeFile file('./my-release-key.keystore')
-            keyAlias 'quik_release'
-            if (keystorePropsFile.exists()) {
-                keystoreProps.load(new FileInputStream(keystorePropsFile))
-            } else if (System.getenv("CI") == "true") {
-//                do nothing
-            } else {
-                throw new GradleException("Keystore properties file not found.")
-            }
-            storePassword keystoreProps['storePassword']
-            keyPassword keystoreProps['keyPassword']
-        }
+//        release {
+//            def keystoreProps = new Properties()
+//            def keystorePropsFile = rootProject.file('./.gradle/.gradlerc')
+//            storeFile file('./my-release-key.keystore')
+//            keyAlias 'quik_release'
+//            if (keystorePropsFile.exists()) {
+//                keystoreProps.load(new FileInputStream(keystorePropsFile))
+//            } else if (System.getenv("CI") == "true") {
+////                do nothing
+//            } else {
+//                throw new GradleException("Keystore properties file not found.")
+//            }
+//            storePassword keystoreProps['storePassword']
+//            keyPassword keystoreProps['keyPassword']
+//        }
     }
 
     buildTypes {
@@ -62,7 +58,7 @@ android {
             minifyEnabled true
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            signingConfig signingConfigs.release
+//            signingConfig signingConfigs.release
         }
     }
 
@@ -75,22 +71,23 @@ android {
         jvmTarget = "1.8"
     }
 
-
     productFlavors {
         withAnalytics { dimension "analytics" }
         noAnalytics {
-            signingConfig signingConfigs.release
+//            signingConfig signingConfigs.release
         }
     }
+
     lint {
         abortOnError false
     }
+
     namespace 'dev.octoshrimpy.quik'
-    if (System.getenv("CI") == "true") {
-        signingConfigs.release.storePassword = System.getenv("keystore_password")
-        signingConfigs.release.keyAlias = System.getenv("key_alias")
-        signingConfigs.release.keyPassword = System.getenv("key_password")
-    }
+//    if (System.getenv("CI") == "true") {
+//        signingConfigs.release.storePassword = System.getenv("keystore_password")
+//        signingConfigs.release.keyAlias = System.getenv("key_alias")
+//        signingConfigs.release.keyPassword = System.getenv("key_password")
+//    }
 }
 
 androidExtensions {
@@ -105,11 +102,11 @@ configurations {
 }
 
 dependencies {
-    // lifecycle
+    // Lifecycle
     implementation "androidx.lifecycle:lifecycle-extensions:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-common-java8:$lifecycle_version"
 
-    // androidx
+    // Androidx
     implementation "androidx.appcompat:appcompat:$androidx_appcompat_version"
     implementation "androidx.constraintlayout:constraintlayout:$androidx_constraintlayout_version"
     implementation "androidx.core:core-ktx:$androidx_core_version"
@@ -117,57 +114,58 @@ dependencies {
     implementation "androidx.viewpager2:viewpager2:$androidx_viewpager_version"
     implementation "com.google.android.material:material:$material_version"
 
-    // conductor
+    // Conductor
     implementation "com.bluelinelabs:conductor:$conductor_version"
     implementation "com.bluelinelabs:conductor-archlifecycle:$conductor_version"
 
-    // glide
+    // Glide
     implementation "com.github.bumptech.glide:glide:$glide_version"
     kapt "com.github.bumptech.glide:compiler:$glide_version"
 
-    // exoplayer
+    // Exoplayer
     implementation "com.github.google.ExoPlayer:exoplayer-core:$exoplayer_version"
     implementation("com.github.google.ExoPlayer:exoplayer-ui:$exoplayer_version", {
         exclude group: "com.android.support", module: "support-media-compat"
     })
 
-    // rxbinding
+    // Rxbinding
     implementation "com.jakewharton.rxbinding2:rxbinding-kotlin:$rxbinding_version"
     implementation "com.jakewharton.rxbinding2:rxbinding-support-v4-kotlin:$rxbinding_version"
 
-    // autodispose
+    // Autodispose
     implementation "com.uber.autodispose:autodispose-android-archcomponents:$autodispose_version"
     implementation "com.uber.autodispose:autodispose-android-archcomponents-test:$autodispose_version"
     implementation "com.uber.autodispose:autodispose-android:$autodispose_version"
     implementation "com.uber.autodispose:autodispose:$autodispose_version"
     implementation "com.uber.autodispose:autodispose-lifecycle:$autodispose_version"
 
-    // dagger
+    // Dagger
     implementation "com.google.dagger:dagger:$dagger_version"
     implementation "com.google.dagger:dagger-android-support:$dagger_version"
     kapt "com.google.dagger:dagger-compiler:$dagger_version"
     kapt "com.google.dagger:dagger-android-processor:$dagger_version"
 //    compileOnly "javax.annotation:jsr250-api:1.0"
-    //Resolve jdk8+ Generation Annotations - javax annotation does not exist
+
+    // Resolve jdk8+ Generation Annotations - javax annotation does not exist
     implementation 'com.github.pengrad:jdk9-deps:1ffe84c468'
 
-//    look into jakarta.annotation-api when switching to java 9
+    // Look into jakarta.annotation-api when switching to java 9
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
 
-    // ezvcard
+    // Ezvcard
     implementation('com.googlecode.ez-vcard:ez-vcard:0.10.4', {
         exclude group: "org.jsoup", module: "jsoup"
         exclude group: "org.freemarker", module: "freemarker"
         exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
     })
 
-    // realm
+    // Realm
     implementation "com.github.realm:realm-android-adapters:$realm_adapters_version"
 //    implementation("io.realm:android-adapters:$realm_adapters_version") { transitive = false }
     kapt "io.realm:realm-annotations:$realm_version"
     kapt "io.realm:realm-annotations-processor:$realm_version"
 
-    // rxjava
+    // Rxjava
     implementation "io.reactivex.rxjava2:rxandroid:$rxandroid_version"
     implementation "io.reactivex.rxjava2:rxjava:$rxjava_version"
     implementation "io.reactivex.rxjava2:rxkotlin:$rxkotlin_version"
@@ -175,7 +173,7 @@ dependencies {
     implementation "com.uber.rxdogtag:rxdogtag-autodispose:$rxdogtag_version"
 
 
-    // testing
+    // Testing
     androidTestImplementation("androidx.test.espresso:espresso-core:$espresso_version", {
         exclude group: "com.android.support", module: "support-annotations"
     })
@@ -184,12 +182,12 @@ dependencies {
     testImplementation "junit:junit:$junit_version"
     testImplementation "org.mockito:mockito-core:$mockito_version"
 
-    // moshi
+    // Moshi
     implementation "com.squareup.moshi:moshi:$moshi_version"
     debugImplementation "com.squareup.moshi:moshi-kotlin:$moshi_version"
     kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshi_version"
 
-    // coroutines
+    // Coroutines
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-rx2:$coroutines_version"

--- a/presentation/src/main/java/com/moez/QKSMS/common/Navigator.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/Navigator.kt
@@ -146,6 +146,11 @@ class Navigator @Inject constructor(
         startActivityExternal(intent)
     }
 
+    fun showUpOpenSourceLink() {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/werunplugged/up_sms"))
+        startActivityExternal(intent)
+    }
+
     fun showSourceCode() {
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/octoshrimpy/quik"))
         startActivityExternal(intent)

--- a/presentation/src/main/java/com/moez/QKSMS/common/QKApplication.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/QKApplication.kt
@@ -51,24 +51,36 @@ import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
 
-class QKApplication : Application(), HasActivityInjector, HasBroadcastReceiverInjector, HasServiceInjector {
+class QKApplication : Application(), HasActivityInjector, HasBroadcastReceiverInjector,
+    HasServiceInjector {
 
     /**
      * Inject these so that they are forced to initialize
      */
     @Suppress("unused")
-    @Inject lateinit var analyticsManager: AnalyticsManager
-    @Suppress("unused")
-    @Inject lateinit var qkMigration: QkMigration
+    @Inject
+    lateinit var analyticsManager: AnalyticsManager
 
-    @Inject lateinit var billingManager: BillingManager
-    @Inject lateinit var dispatchingActivityInjector: DispatchingAndroidInjector<Activity>
-    @Inject lateinit var dispatchingBroadcastReceiverInjector: DispatchingAndroidInjector<BroadcastReceiver>
-    @Inject lateinit var dispatchingServiceInjector: DispatchingAndroidInjector<Service>
-    @Inject lateinit var fileLoggingTree: FileLoggingTree
-    @Inject lateinit var nightModeManager: NightModeManager
-    @Inject lateinit var realmMigration: QkRealmMigration
-    @Inject lateinit var referralManager: ReferralManager
+    @Suppress("unused")
+    @Inject
+    lateinit var qkMigration: QkMigration
+
+    @Inject
+    lateinit var billingManager: BillingManager
+    @Inject
+    lateinit var dispatchingActivityInjector: DispatchingAndroidInjector<Activity>
+    @Inject
+    lateinit var dispatchingBroadcastReceiverInjector: DispatchingAndroidInjector<BroadcastReceiver>
+    @Inject
+    lateinit var dispatchingServiceInjector: DispatchingAndroidInjector<Service>
+    @Inject
+    lateinit var fileLoggingTree: FileLoggingTree
+    @Inject
+    lateinit var nightModeManager: NightModeManager
+    @Inject
+    lateinit var realmMigration: QkRealmMigration
+    @Inject
+    lateinit var referralManager: ReferralManager
 
     override fun onCreate() {
         super.onCreate()
@@ -77,11 +89,14 @@ class QKApplication : Application(), HasActivityInjector, HasBroadcastReceiverIn
         appComponent.inject(this)
 
         Realm.init(this)
-        Realm.setDefaultConfiguration(RealmConfiguration.Builder()
+        Realm.setDefaultConfiguration(
+            RealmConfiguration.Builder()
+                .allowWritesOnUiThread(true)
                 .compactOnLaunch()
                 .migration(realmMigration)
                 .schemaVersion(QkRealmMigration.SchemaVersion)
-                .build())
+                .build()
+        )
 
         qkMigration.performMigration()
 
@@ -94,18 +109,19 @@ class QKApplication : Application(), HasActivityInjector, HasBroadcastReceiverIn
         nightModeManager.updateCurrentTheme()
 
         val fontRequest = FontRequest(
-                "com.google.android.gms.fonts",
-                "com.google.android.gms",
-                "Noto Color Emoji Compat",
-                R.array.com_google_android_gms_fonts_certs)
+            "com.google.android.gms.fonts",
+            "com.google.android.gms",
+            "Noto Color Emoji Compat",
+            R.array.com_google_android_gms_fonts_certs
+        )
 
         EmojiCompat.init(FontRequestEmojiCompatConfig(this, fontRequest))
 
         Timber.plant(Timber.DebugTree(), CrashlyticsTree(), fileLoggingTree)
 
         RxDogTag.builder()
-                .configureWith(AutoDisposeConfigurer::configure)
-                .install()
+            .configureWith(AutoDisposeConfigurer::configure)
+            .install()
     }
 
     override fun activityInjector(): AndroidInjector<Activity> {

--- a/presentation/src/main/java/com/moez/QKSMS/common/util/QkChooserTargetService.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/util/QkChooserTargetService.kt
@@ -44,6 +44,7 @@ class QkChooserTargetService : ChooserTargetService() {
         super.onCreate()
     }
 
+    @Deprecated("Deprecated in Java")
     override fun onGetChooserTargets(targetActivityName: ComponentName?, matchedFilter: IntentFilter?): List<ChooserTarget> {
         return conversationRepo.getTopConversations()
                 .take(3)

--- a/presentation/src/main/java/com/moez/QKSMS/feature/backup/BackupActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/backup/BackupActivity.kt
@@ -43,6 +43,7 @@ class BackupActivity : QkThemedActivity() {
         }
     }
 
+    @Deprecated("Deprecated in Java")
     override fun onBackPressed() {
         if (!router.handleBack()) {
             super.onBackPressed()

--- a/presentation/src/main/java/com/moez/QKSMS/feature/blocking/BlockingActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/blocking/BlockingActivity.kt
@@ -42,6 +42,7 @@ class BlockingActivity : QkThemedActivity() {
         }
     }
 
+    @Deprecated("Deprecated in Java")
     override fun onBackPressed() {
         if (!router.handleBack()) {
             super.onBackPressed()

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
@@ -369,6 +369,7 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
         return super.getColoredMenuItems() + R.id.call
     }
 
+    @Deprecated("Deprecated in Java")
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         when {
             requestCode == SelectContactRequestCode -> {
@@ -403,6 +404,7 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
         super.onRestoreInstanceState(savedInstanceState)
     }
 
+    @Deprecated("Deprecated in Java")
     override fun onBackPressed() = backPressedIntent.onNext(Unit)
 
 }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/conversationinfo/ConversationInfoActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/conversationinfo/ConversationInfoActivity.kt
@@ -43,6 +43,7 @@ class ConversationInfoActivity : QkThemedActivity() {
         }
     }
 
+    @Deprecated("Deprecated in Java")
     override fun onBackPressed() {
         if (!router.handleBack()) {
             super.onBackPressed()

--- a/presentation/src/main/java/com/moez/QKSMS/feature/main/MainActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/main/MainActivity.kt
@@ -100,15 +100,15 @@ class MainActivity : QkThemedActivity(), MainView {
                 backup.clicks().map { NavItem.BACKUP },
                 scheduled.clicks().map { NavItem.SCHEDULED },
                 blocking.clicks().map { NavItem.BLOCKING },
-                settings.clicks().map { NavItem.SETTINGS },
+                settings.clicks().map { NavItem.SETTINGS }))
 //                plus.clicks().map { NavItem.PLUS },
 //                help.clicks().map { NavItem.HELP },
-                invite.clicks().map { NavItem.INVITE }))
+//                invite.clicks().map { NavItem.INVITE }))
     }
     override val optionsItemIntent: Subject<Int> = PublishSubject.create()
 //    override val plusBannerIntent by lazy { plusBanner.clicks() }
-    override val dismissRatingIntent by lazy { rateDismiss.clicks() }
-    override val rateIntent by lazy { rateOkay.clicks() }
+//    override val dismissRatingIntent by lazy { rateDismiss.clicks() }
+//    override val rateIntent by lazy { rateOkay.clicks() }
     override val conversationsSelectedIntent by lazy { conversationsAdapter.selectionChanges }
     override val confirmDeleteIntent: Subject<List<Long>> = PublishSubject.create()
     override val swipeConversationIntent by lazy { itemTouchCallback.swipes }
@@ -172,14 +172,14 @@ class MainActivity : QkThemedActivity(), MainView {
                             }
 
                     // Miscellaneous views
-                    listOf(plusBadge1, plusBadge2).forEach { badge ->
-                        badge.setBackgroundTint(theme.theme)
-                        badge.setTextColor(theme.textPrimary)
-                    }
+//                    listOf(plusBadge1, plusBadge2).forEach { badge ->
+//                        badge.setBackgroundTint(theme.theme)
+//                        badge.setTextColor(theme.textPrimary)
+//                    }
                     syncingProgress?.progressTintList = ColorStateList.valueOf(theme.theme)
                     syncingProgress?.indeterminateTintList = ColorStateList.valueOf(theme.theme)
-                    plusIcon.setTint(theme.theme)
-                    rateIcon.setTint(theme.theme)
+//                    plusIcon.setTint(theme.theme)
+//                    rateIcon.setTint(theme.theme)
                     compose.setBackgroundTint(theme.theme)
 
                     // Set the FAB compose icon color
@@ -235,12 +235,12 @@ class MainActivity : QkThemedActivity(), MainView {
         toolbar.menu.findItem(R.id.unread)?.isVisible = !markRead && selectedConversations != 0
         toolbar.menu.findItem(R.id.block)?.isVisible = selectedConversations != 0
 
-        listOf(plusBadge1, plusBadge2).forEach { badge ->
-            badge.isVisible = drawerBadgesExperiment.variant && !state.upgraded
-        }
+//        listOf(plusBadge1, plusBadge2).forEach { badge ->
+//            badge.isVisible = drawerBadgesExperiment.variant && !state.upgraded
+//        }
 //        plus.isVisible = state.upgraded
-        plusBanner.isVisible = !state.upgraded
-        rateLayout.setVisible(state.showRating)
+//        plusBanner.isVisible = !state.upgraded
+//        rateLayout.setVisible(state.showRating)
 
         compose.setVisible(state.page is Inbox || state.page is Archived)
         conversationsAdapter.emptyView = empty.takeIf { state.page is Inbox || state.page is Archived }
@@ -420,6 +420,7 @@ class MainActivity : QkThemedActivity(), MainView {
         return true
     }
 
+    @Deprecated("Deprecated in Java")
     override fun onBackPressed() {
         backPressedSubject.onNext(NavItem.BACK)
     }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/main/MainView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/main/MainView.kt
@@ -34,8 +34,8 @@ interface MainView : QkView<MainState> {
     val navigationIntent: Observable<NavItem>
     val optionsItemIntent: Observable<Int>
 //    val plusBannerIntent: Observable<*>
-    val dismissRatingIntent: Observable<*>
-    val rateIntent: Observable<*>
+//    val dismissRatingIntent: Observable<*>
+//    val rateIntent: Observable<*>
     val conversationsSelectedIntent: Observable<List<Long>>
     val confirmDeleteIntent: Observable<List<Long>>
     val swipeConversationIntent: Observable<Pair<Long, Int>>

--- a/presentation/src/main/java/com/moez/QKSMS/feature/main/MainViewModel.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/main/MainViewModel.kt
@@ -406,16 +406,16 @@ class MainViewModel @Inject constructor(
 //                    navigator.showQksmsPlusActivity("main_banner")
 //                }
 
-        view.rateIntent
-                .autoDisposable(view.scope())
-                .subscribe {
-                    navigator.showRating()
-                    ratingManager.rate()
-                }
-
-        view.dismissRatingIntent
-                .autoDisposable(view.scope())
-                .subscribe { ratingManager.dismiss() }
+//        view.rateIntent
+//                .autoDisposable(view.scope())
+//                .subscribe {
+//                    navigator.showRating()
+//                    ratingManager.rate()
+//                }
+//
+//        view.dismissRatingIntent
+//                .autoDisposable(view.scope())
+//                .subscribe { ratingManager.dismiss() }
 
         view.conversationsSelectedIntent
                 .withLatestFrom(state) { selection, state ->

--- a/presentation/src/main/java/com/moez/QKSMS/feature/notificationprefs/NotificationPrefsActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/notificationprefs/NotificationPrefsActivity.kt
@@ -136,6 +136,7 @@ class NotificationPrefsActivity : QkThemedActivity(), NotificationPrefsView {
         actionsDialog.show(this)
     }
 
+    @Deprecated("Deprecated in Java")
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         if (requestCode == 123 && resultCode == Activity.RESULT_OK) {

--- a/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsActivity.kt
@@ -42,6 +42,7 @@ class SettingsActivity : QkThemedActivity() {
         }
     }
 
+    @Deprecated("Deprecated in Java")
     override fun onBackPressed() {
         if (!router.handleBack()) {
             super.onBackPressed()

--- a/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsState.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsState.kt
@@ -37,7 +37,7 @@ data class SettingsState(
     val signature: String = "",
     val textSizeSummary: String = "",
     val textSizeId: Int = Preferences.TEXT_SIZE_NORMAL,
-    val systemFontEnabled: Boolean = false,
+    val systemFontEnabled: Boolean = true,
     val splitSmsEnabled: Boolean = false,
     val stripUnicodeEnabled: Boolean = false,
     val mobileOnly: Boolean = false,

--- a/presentation/src/main/java/com/moez/QKSMS/feature/settings/about/AboutPresenter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/settings/about/AboutPresenter.kt
@@ -18,11 +18,12 @@
  */
 package dev.octoshrimpy.quik.feature.settings.about
 
+import android.util.Log
+import com.uber.autodispose.android.lifecycle.scope
+import com.uber.autodispose.autoDisposable
 import dev.octoshrimpy.quik.R
 import dev.octoshrimpy.quik.common.Navigator
 import dev.octoshrimpy.quik.common.base.QkPresenter
-import com.uber.autodispose.android.lifecycle.scope
-import com.uber.autodispose.autoDisposable
 import javax.inject.Inject
 
 class AboutPresenter @Inject constructor(
@@ -33,20 +34,23 @@ class AboutPresenter @Inject constructor(
         super.bindIntents(view)
 
         view.preferenceClicks()
-                .autoDisposable(view.scope())
-                .subscribe { preference ->
-                    when (preference.id) {
-                        R.id.developer -> navigator.showDeveloper()
+            .autoDisposable(view.scope())
+            .subscribe { preference ->
+                when (preference.id) {
+                    R.id.openSourceHeader -> view.toggleOpenSourceContentVisibility()
 
-                        R.id.source -> navigator.showSourceCode()
+                    R.id.up_open_source_link -> navigator.showUpOpenSourceLink()
 
-                        R.id.changelog -> navigator.showChangelog()
+                    R.id.developer -> navigator.showDeveloper()
 
-                        R.id.contact -> navigator.showSupport()
+                    R.id.source -> navigator.showSourceCode()
 
-                        R.id.license -> navigator.showLicense()
-                    }
+                    R.id.changelog -> navigator.showChangelog()
+
+                    R.id.contact -> navigator.showSupport()
+
+                    R.id.license -> navigator.showLicense()
                 }
+            }
     }
-
 }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/settings/about/AboutView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/settings/about/AboutView.kt
@@ -26,4 +26,6 @@ interface AboutView : QkViewContract<Unit> {
 
     fun preferenceClicks(): Observable<PreferenceView>
 
+    fun toggleOpenSourceContentVisibility()
+
 }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/settings/swipe/SwipeActionsController.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/settings/swipe/SwipeActionsController.kt
@@ -98,5 +98,4 @@ class SwipeActionsController : QkController<SwipeActionsView, SwipeActionsState,
         leftIcon.setImageResource(state.leftIcon)
         leftLabel.text = state.leftLabel
     }
-
 }

--- a/presentation/src/main/res/layout/about_controller.xml
+++ b/presentation/src/main/res/layout/about_controller.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (C) 2019 Moez Bhatti <moez.bhatti@gmail.com>
   ~
   ~ This file is part of QKSMS.
@@ -33,6 +32,7 @@
         android:paddingTop="8dp"
         android:paddingBottom="8dp">
 
+        <!-- Version -->
         <dev.octoshrimpy.quik.common.widget.PreferenceView
             android:id="@+id/version"
             android:layout_width="match_parent"
@@ -40,47 +40,75 @@
             app:title="@string/about_version_title"
             tools:summary="3.0.8" />
 
+        <!-- UP Open Source -->
         <dev.octoshrimpy.quik.common.widget.PreferenceView
-            android:id="@+id/developer"
+            android:id="@+id/up_open_source_link"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:summary="@string/about_developer"
-            app:title="@string/about_developer_title" />
+            app:summary="@string/up_open_source_link"
+            app:title="@string/up_open_source_link_title" />
 
+        <!-- Open Source Credit Header -->
         <dev.octoshrimpy.quik.common.widget.PreferenceView
-            android:id="@+id/source"
+            android:id="@+id/openSourceHeader"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:summary="@string/about_source"
-            app:title="@string/about_source_title" />
+            app:summary="Tap to expand"
+            app:title="@string/open_source_credit_title" />
 
-        <dev.octoshrimpy.quik.common.widget.PreferenceView
-            android:id="@+id/changelog"
+        <!-- Expandable Content -->
+        <LinearLayout
+            android:id="@+id/openSourceContent"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:summary="@string/about_changelog"
-            app:title="@string/about_changelog_title" />
+            android:orientation="vertical"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
+            android:visibility="gone">
 
-        <dev.octoshrimpy.quik.common.widget.PreferenceView
-            android:id="@+id/contact"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:summary="@string/about_contact"
-            app:title="@string/about_contact_title" />
+            <dev.octoshrimpy.quik.common.widget.PreferenceView
+                android:id="@+id/developer"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:summary="@string/about_developer"
+                app:title="@string/about_developer_title" />
 
-        <dev.octoshrimpy.quik.common.widget.PreferenceView
-            android:id="@+id/license"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:summary="@string/about_license"
-            app:title="@string/about_license_title" />
+            <dev.octoshrimpy.quik.common.widget.PreferenceView
+                android:id="@+id/source"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:summary="@string/about_source"
+                app:title="@string/about_source_title" />
 
-        <dev.octoshrimpy.quik.common.widget.PreferenceView
-            android:id="@+id/copyright"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:summary="@string/about_copyright"
-            app:title="@string/about_copyright_title" />
+            <dev.octoshrimpy.quik.common.widget.PreferenceView
+                android:id="@+id/changelog"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:summary="@string/about_changelog"
+                app:title="@string/about_changelog_title" />
+
+            <dev.octoshrimpy.quik.common.widget.PreferenceView
+                android:id="@+id/contact"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:summary="@string/about_contact"
+                app:title="@string/about_contact_title" />
+
+            <dev.octoshrimpy.quik.common.widget.PreferenceView
+                android:id="@+id/license"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:summary="@string/about_license"
+                app:title="@string/about_license_title" />
+
+            <dev.octoshrimpy.quik.common.widget.PreferenceView
+                android:id="@+id/copyright"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:summary="@string/about_copyright"
+                app:title="@string/about_copyright_title" />
+
+        </LinearLayout>
 
     </LinearLayout>
 

--- a/presentation/src/main/res/layout/drawer_view.xml
+++ b/presentation/src/main/res/layout/drawer_view.xml
@@ -83,17 +83,17 @@
                 style="@style/DrawerText"
                 android:text="@string/backup_title" />
 
-            <dev.octoshrimpy.quik.common.widget.QkTextView
-                android:id="@+id/plusBadge1"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:background="@drawable/rounded_rectangle_2dp"
-                android:padding="4dp"
-                android:text="@string/title_qksms_plus"
-                android:textStyle="bold"
-                app:textSize="tertiary"
-                tools:backgroundTint="@color/tools_theme"
-                tools:textColor="@color/textPrimaryDark" />
+<!--            <dev.octoshrimpy.quik.common.widget.QkTextView-->
+<!--                android:id="@+id/plusBadge1"-->
+<!--                android:layout_width="wrap_content"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:background="@drawable/rounded_rectangle_2dp"-->
+<!--                android:padding="4dp"-->
+<!--                android:text="@string/title_qksms_plus"-->
+<!--                android:textStyle="bold"-->
+<!--                app:textSize="tertiary"-->
+<!--                tools:backgroundTint="@color/tools_theme"-->
+<!--                tools:textColor="@color/textPrimaryDark" />-->
 
         </LinearLayout>
 
@@ -110,17 +110,17 @@
                 style="@style/DrawerText"
                 android:text="@string/drawer_scheduled" />
 
-            <dev.octoshrimpy.quik.common.widget.QkTextView
-                android:id="@+id/plusBadge2"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:background="@drawable/rounded_rectangle_2dp"
-                android:padding="4dp"
-                android:text="@string/title_qksms_plus"
-                android:textStyle="bold"
-                app:textSize="tertiary"
-                tools:backgroundTint="@color/tools_theme"
-                tools:textColor="@color/textPrimaryDark" />
+<!--            <dev.octoshrimpy.quik.common.widget.QkTextView-->
+<!--                android:id="@+id/plusBadge2"-->
+<!--                android:layout_width="wrap_content"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:background="@drawable/rounded_rectangle_2dp"-->
+<!--                android:padding="4dp"-->
+<!--                android:text="@string/title_qksms_plus"-->
+<!--                android:textStyle="bold"-->
+<!--                app:textSize="tertiary"-->
+<!--                tools:backgroundTint="@color/tools_theme"-->
+<!--                tools:textColor="@color/textPrimaryDark" />-->
 
         </LinearLayout>
 
@@ -191,162 +191,147 @@
 
 <!--        </LinearLayout>-->
 
-        <LinearLayout
-            android:id="@+id/invite"
-            style="@style/DrawerRow">
+<!--        <androidx.constraintlayout.widget.ConstraintLayout-->
+<!--            android:id="@+id/plusBanner"-->
+<!--            android:layout_width="match_parent"-->
+<!--            android:layout_height="wrap_content"-->
+<!--            android:layout_marginStart="8dp"-->
+<!--            android:layout_marginTop="8dp"-->
+<!--            android:layout_marginEnd="8dp"-->
+<!--            android:background="@drawable/rounded_rectangle_outline_2dp"-->
+<!--            android:backgroundTint="?android:attr/divider"-->
+<!--            android:foreground="?attr/selectableItemBackground"-->
+<!--            android:padding="16dp">-->
 
-            <ImageView
-                style="@style/DrawerIcon"
-                android:src="@drawable/ic_people_black_24dp"
-                android:tint="?android:attr/textColorSecondary" />
+<!--            <ImageView-->
+<!--                android:id="@+id/plusIcon"-->
+<!--                android:layout_width="24dp"-->
+<!--                android:layout_height="24dp"-->
+<!--                android:src="@drawable/ic_star_black_24dp"-->
+<!--                app:layout_constraintBottom_toBottomOf="parent"-->
+<!--                app:layout_constraintStart_toStartOf="parent"-->
+<!--                app:layout_constraintTop_toTopOf="parent"-->
+<!--                tools:tint="@color/tools_theme" />-->
 
-            <dev.octoshrimpy.quik.common.widget.QkTextView
-                style="@style/DrawerText"
-                android:text="@string/drawer_invite" />
+<!--            <dev.octoshrimpy.quik.common.widget.QkTextView-->
+<!--                android:id="@+id/plusTitle"-->
+<!--                android:layout_width="0dp"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:layout_marginStart="16dp"-->
+<!--                android:layout_marginEnd="16dp"-->
+<!--                android:text="@string/drawer_plus_banner_title"-->
+<!--                android:textColor="?android:attr/textColorPrimary"-->
+<!--                android:textStyle="bold"-->
+<!--                app:layout_constraintEnd_toStartOf="@id/plusNext"-->
+<!--                app:layout_constraintStart_toEndOf="@id/plusIcon"-->
+<!--                app:layout_constraintTop_toTopOf="parent"-->
+<!--                app:textSize="primary" />-->
 
-        </LinearLayout>
+<!--            <dev.octoshrimpy.quik.common.widget.QkTextView-->
+<!--                android:id="@+id/plusSummary"-->
+<!--                android:layout_width="0dp"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:layout_marginTop="2dp"-->
+<!--                android:text="@string/drawer_plus_banner_summary"-->
+<!--                android:textColor="?android:attr/textColorSecondary"-->
+<!--                app:layout_constraintEnd_toEndOf="@id/plusTitle"-->
+<!--                app:layout_constraintStart_toStartOf="@id/plusTitle"-->
+<!--                app:layout_constraintTop_toBottomOf="@id/plusTitle"-->
+<!--                app:textSize="secondary" />-->
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/plusBanner"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            android:layout_marginTop="8dp"
-            android:layout_marginEnd="8dp"
-            android:background="@drawable/rounded_rectangle_outline_2dp"
-            android:backgroundTint="?android:attr/divider"
-            android:foreground="?attr/selectableItemBackground"
-            android:padding="16dp">
+<!--            <ImageView-->
+<!--                android:id="@+id/plusNext"-->
+<!--                android:layout_width="24dp"-->
+<!--                android:layout_height="24dp"-->
+<!--                android:src="@drawable/ic_chevron_right_black_24dp"-->
+<!--                android:tint="?android:attr/textColorTertiary"-->
+<!--                app:layout_constraintBottom_toBottomOf="parent"-->
+<!--                app:layout_constraintEnd_toEndOf="parent"-->
+<!--                app:layout_constraintTop_toTopOf="parent" />-->
 
-            <ImageView
-                android:id="@+id/plusIcon"
-                android:layout_width="24dp"
-                android:layout_height="24dp"
-                android:src="@drawable/ic_star_black_24dp"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                tools:tint="@color/tools_theme" />
+<!--        </androidx.constraintlayout.widget.ConstraintLayout>-->
 
-            <dev.octoshrimpy.quik.common.widget.QkTextView
-                android:id="@+id/plusTitle"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="16dp"
-                android:layout_marginEnd="16dp"
-                android:text="@string/drawer_plus_banner_title"
-                android:textColor="?android:attr/textColorPrimary"
-                android:textStyle="bold"
-                app:layout_constraintEnd_toStartOf="@id/plusNext"
-                app:layout_constraintStart_toEndOf="@id/plusIcon"
-                app:layout_constraintTop_toTopOf="parent"
-                app:textSize="primary" />
+<!--        <androidx.constraintlayout.widget.ConstraintLayout-->
+<!--            android:id="@+id/rateLayout"-->
+<!--            android:layout_width="match_parent"-->
+<!--            android:layout_height="wrap_content"-->
+<!--            android:layout_marginStart="8dp"-->
+<!--            android:layout_marginTop="8dp"-->
+<!--            android:layout_marginEnd="8dp"-->
+<!--            android:background="@drawable/rounded_rectangle_outline_2dp"-->
+<!--            android:backgroundTint="?android:attr/divider">-->
 
-            <dev.octoshrimpy.quik.common.widget.QkTextView
-                android:id="@+id/plusSummary"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="2dp"
-                android:text="@string/drawer_plus_banner_summary"
-                android:textColor="?android:attr/textColorSecondary"
-                app:layout_constraintEnd_toEndOf="@id/plusTitle"
-                app:layout_constraintStart_toStartOf="@id/plusTitle"
-                app:layout_constraintTop_toBottomOf="@id/plusTitle"
-                app:textSize="secondary" />
+<!--            <ImageView-->
+<!--                android:id="@+id/rateIcon"-->
+<!--                android:layout_width="24dp"-->
+<!--                android:layout_height="24dp"-->
+<!--                android:layout_marginStart="16dp"-->
+<!--                android:src="@drawable/ic_favorite_black_24dp"-->
+<!--                app:layout_constraintBottom_toBottomOf="@id/rateSummary"-->
+<!--                app:layout_constraintStart_toStartOf="parent"-->
+<!--                app:layout_constraintTop_toTopOf="@id/rateTitle"-->
+<!--                tools:tint="@color/tools_theme" />-->
 
-            <ImageView
-                android:id="@+id/plusNext"
-                android:layout_width="24dp"
-                android:layout_height="24dp"
-                android:src="@drawable/ic_chevron_right_black_24dp"
-                android:tint="?android:attr/textColorTertiary"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+<!--            <dev.octoshrimpy.quik.common.widget.QkTextView-->
+<!--                android:id="@+id/rateTitle"-->
+<!--                android:layout_width="0dp"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:layout_marginStart="16dp"-->
+<!--                android:layout_marginTop="16dp"-->
+<!--                android:layout_marginEnd="16dp"-->
+<!--                android:text="@string/rate_title"-->
+<!--                android:textColor="?android:attr/textColorPrimary"-->
+<!--                android:textStyle="bold"-->
+<!--                app:layout_constraintEnd_toEndOf="parent"-->
+<!--                app:layout_constraintStart_toEndOf="@id/rateIcon"-->
+<!--                app:layout_constraintTop_toTopOf="parent"-->
+<!--                app:textSize="primary" />-->
 
-        </androidx.constraintlayout.widget.ConstraintLayout>
+<!--            <dev.octoshrimpy.quik.common.widget.QkTextView-->
+<!--                android:id="@+id/rateSummary"-->
+<!--                android:layout_width="0dp"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:layout_marginTop="2dp"-->
+<!--                android:layout_marginEnd="16dp"-->
+<!--                android:text="@string/rate_summary"-->
+<!--                android:textColor="?android:attr/textColorSecondary"-->
+<!--                app:layout_constraintEnd_toEndOf="@id/rateTitle"-->
+<!--                app:layout_constraintStart_toStartOf="@id/rateTitle"-->
+<!--                app:layout_constraintTop_toBottomOf="@id/rateTitle"-->
+<!--                app:textSize="secondary" />-->
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/rateLayout"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            android:layout_marginTop="8dp"
-            android:layout_marginEnd="8dp"
-            android:background="@drawable/rounded_rectangle_outline_2dp"
-            android:backgroundTint="?android:attr/divider">
+<!--            <dev.octoshrimpy.quik.common.widget.QkTextView-->
+<!--                android:id="@+id/rateDismiss"-->
+<!--                android:layout_width="wrap_content"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:layout_marginStart="16dp"-->
+<!--                android:layout_marginTop="8dp"-->
+<!--                android:paddingStart="16dp"-->
+<!--                android:paddingTop="16dp"-->
+<!--                android:paddingBottom="16dp"-->
+<!--                android:text="@string/rate_dismiss"-->
+<!--                android:textColor="?android:attr/textColorTertiary"-->
+<!--                android:textStyle="bold"-->
+<!--                app:layout_constraintEnd_toStartOf="@id/rateOkay"-->
+<!--                app:layout_constraintTop_toBottomOf="@id/rateSummary"-->
+<!--                app:textSize="secondary" />-->
 
-            <ImageView
-                android:id="@+id/rateIcon"
-                android:layout_width="24dp"
-                android:layout_height="24dp"
-                android:layout_marginStart="16dp"
-                android:src="@drawable/ic_favorite_black_24dp"
-                app:layout_constraintBottom_toBottomOf="@id/rateSummary"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="@id/rateTitle"
-                tools:tint="@color/tools_theme" />
+<!--            <dev.octoshrimpy.quik.common.widget.QkTextView-->
+<!--                android:id="@+id/rateOkay"-->
+<!--                android:layout_width="wrap_content"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:layout_marginTop="8dp"-->
+<!--                android:layout_marginEnd="8dp"-->
+<!--                android:background="?attr/selectableItemBackground"-->
+<!--                android:padding="16dp"-->
+<!--                android:text="@string/rate_okay"-->
+<!--                android:textColor="?android:attr/textColorSecondary"-->
+<!--                android:textStyle="bold"-->
+<!--                app:layout_constraintEnd_toEndOf="parent"-->
+<!--                app:layout_constraintTop_toBottomOf="@id/rateSummary"-->
+<!--                app:textSize="secondary" />-->
 
-            <dev.octoshrimpy.quik.common.widget.QkTextView
-                android:id="@+id/rateTitle"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="16dp"
-                android:layout_marginTop="16dp"
-                android:layout_marginEnd="16dp"
-                android:text="@string/rate_title"
-                android:textColor="?android:attr/textColorPrimary"
-                android:textStyle="bold"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/rateIcon"
-                app:layout_constraintTop_toTopOf="parent"
-                app:textSize="primary" />
-
-            <dev.octoshrimpy.quik.common.widget.QkTextView
-                android:id="@+id/rateSummary"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="2dp"
-                android:layout_marginEnd="16dp"
-                android:text="@string/rate_summary"
-                android:textColor="?android:attr/textColorSecondary"
-                app:layout_constraintEnd_toEndOf="@id/rateTitle"
-                app:layout_constraintStart_toStartOf="@id/rateTitle"
-                app:layout_constraintTop_toBottomOf="@id/rateTitle"
-                app:textSize="secondary" />
-
-            <dev.octoshrimpy.quik.common.widget.QkTextView
-                android:id="@+id/rateDismiss"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="16dp"
-                android:layout_marginTop="8dp"
-                android:paddingStart="16dp"
-                android:paddingTop="16dp"
-                android:paddingBottom="16dp"
-                android:text="@string/rate_dismiss"
-                android:textColor="?android:attr/textColorTertiary"
-                android:textStyle="bold"
-                app:layout_constraintEnd_toStartOf="@id/rateOkay"
-                app:layout_constraintTop_toBottomOf="@id/rateSummary"
-                app:textSize="secondary" />
-
-            <dev.octoshrimpy.quik.common.widget.QkTextView
-                android:id="@+id/rateOkay"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:layout_marginEnd="8dp"
-                android:background="?attr/selectableItemBackground"
-                android:padding="16dp"
-                android:text="@string/rate_okay"
-                android:textColor="?android:attr/textColorSecondary"
-                android:textStyle="bold"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/rateSummary"
-                app:textSize="secondary" />
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
+<!--        </androidx.constraintlayout.widget.ConstraintLayout>-->
 
     </LinearLayout>
 

--- a/presentation/src/main/res/layout/swipe_actions_controller.xml
+++ b/presentation/src/main/res/layout/swipe_actions_controller.xml
@@ -60,7 +60,7 @@
                 app:layout_constraintStart_toStartOf="@id/rightTitle"
                 app:layout_constraintTop_toBottomOf="@id/rightTitle"
                 app:textSize="secondary"
-                tools:text="Archive" />
+                tools:text="Delete" />
 
             <dev.octoshrimpy.quik.common.widget.QkTextView
                 android:id="@+id/rightChange"
@@ -104,7 +104,7 @@
                 app:layout_constraintStart_toStartOf="@id/rightBackground"
                 app:layout_constraintTop_toTopOf="@id/rightBackground"
                 tools:backgroundTint="@color/tools_theme"
-                tools:src="@drawable/ic_archive_white_24dp"
+                tools:src="@drawable/ic_delete_white_24dp"
                 tools:tint="@color/textPrimaryDark" />
 
             <ImageView

--- a/presentation/src/main/res/values-ar/strings.xml
+++ b/presentation/src/main/res/values-ar/strings.xml
@@ -387,6 +387,9 @@
     </plurals>
     <string name="notification_message_failed_title">لم ترسَل الرسالة</string>
     <string name="notification_message_failed_text">فشل الإرسال إلى %s</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>نظام</item>
         <item>الغاء التفعيل</item>

--- a/presentation/src/main/res/values-bn/strings.xml
+++ b/presentation/src/main/res/values-bn/strings.xml
@@ -366,6 +366,9 @@
     </plurals>
     <string name="notification_message_failed_title">বার্তা পাঠাতে ব্যর্থ</string>
     <string name="notification_message_failed_text">%s এর কাছে বার্তাটি পাঠাতে ব্যর্থ</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>পদ্ধতি</item>
         <item>অক্ষম</item>

--- a/presentation/src/main/res/values-cs/strings.xml
+++ b/presentation/src/main/res/values-cs/strings.xml
@@ -376,6 +376,9 @@
     </plurals>
     <string name="notification_message_failed_title">Zpráva nebyla odeslána</string>
     <string name="notification_message_failed_text">Odeslání zprávy pro %s se nezdařilo</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>Dle systému</item>
         <item>Vypnuto</item>

--- a/presentation/src/main/res/values-da/strings.xml
+++ b/presentation/src/main/res/values-da/strings.xml
@@ -366,6 +366,9 @@
     </plurals>
     <string name="notification_message_failed_title">Besked ikke afsendt</string>
     <string name="notification_message_failed_text">Mislykkedes at afsende beskeden til %s</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>System</item>
         <item>Deaktiveret</item>

--- a/presentation/src/main/res/values-de/strings.xml
+++ b/presentation/src/main/res/values-de/strings.xml
@@ -366,6 +366,9 @@
     </plurals>
     <string name="notification_message_failed_title">Nachricht wurde nicht gesendet</string>
     <string name="notification_message_failed_text">Die Nachricht konnte nicht an %s gesendet werden</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>System</item>
         <item>Deaktiviert</item>

--- a/presentation/src/main/res/values-el/strings.xml
+++ b/presentation/src/main/res/values-el/strings.xml
@@ -366,6 +366,9 @@
     </plurals>
     <string name="notification_message_failed_title">Message not sent</string>
     <string name="notification_message_failed_text">The message to %s failed to send</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>System</item>
         <item>Disabled</item>

--- a/presentation/src/main/res/values-es/strings.xml
+++ b/presentation/src/main/res/values-es/strings.xml
@@ -366,6 +366,9 @@
     </plurals>
     <string name="notification_message_failed_title">Mensaje no enviado</string>
     <string name="notification_message_failed_text">El mensaje a %s no se pudo enviar</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>Sistema</item>
         <item>Desactivado</item>

--- a/presentation/src/main/res/values-fa/strings.xml
+++ b/presentation/src/main/res/values-fa/strings.xml
@@ -366,6 +366,9 @@
     </plurals>
     <string name="notification_message_failed_title">پیام ارسال نشد</string>
     <string name="notification_message_failed_text">پیام به %s فرستاده نشد</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>سامانه</item>
         <item>غیرفعال</item>

--- a/presentation/src/main/res/values-fi/strings.xml
+++ b/presentation/src/main/res/values-fi/strings.xml
@@ -366,6 +366,9 @@
     </plurals>
     <string name="notification_message_failed_title">Viestiä ei lähetetty</string>
     <string name="notification_message_failed_text">Viestin lähetys vastaanottajalle %s epäonnistui</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>Järjestelmä</item>
         <item>Pois käytöstä</item>

--- a/presentation/src/main/res/values-fr/strings.xml
+++ b/presentation/src/main/res/values-fr/strings.xml
@@ -366,6 +366,10 @@
     </plurals>
     <string name="notification_message_failed_title">Message non envoyé</string>
     <string name="notification_message_failed_text">Le message à %s n\'a pu être envoyé</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
+
     <string-array name="night_modes">
         <item>Système</item>
         <item>Désactivé</item>

--- a/presentation/src/main/res/values-gd/strings.xml
+++ b/presentation/src/main/res/values-gd/strings.xml
@@ -376,6 +376,9 @@
     </plurals>
     <string name="notification_message_failed_title">Message not sent</string>
     <string name="notification_message_failed_text">The message to %s failed to send</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>System</item>
         <item>Disabled</item>

--- a/presentation/src/main/res/values-hi/strings.xml
+++ b/presentation/src/main/res/values-hi/strings.xml
@@ -366,6 +366,9 @@
     </plurals>
     <string name="notification_message_failed_title">संदेश नही भेजा गया</string>
     <string name="notification_message_failed_text">%s को संदेश भेजने में असफल</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>प्रणाली</item>
         <item>अक्षम करें</item>

--- a/presentation/src/main/res/values-hr/strings.xml
+++ b/presentation/src/main/res/values-hr/strings.xml
@@ -371,6 +371,9 @@
     </plurals>
     <string name="notification_message_failed_title">Poruka nije poslana</string>
     <string name="notification_message_failed_text">Poruka za %s nije se uspjela poslati</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>Sustav</item>
         <item>Onemogućeno</item>

--- a/presentation/src/main/res/values-hu/strings.xml
+++ b/presentation/src/main/res/values-hu/strings.xml
@@ -366,6 +366,9 @@
     </plurals>
     <string name="notification_message_failed_title">Az üzenet küldése sikertelen</string>
     <string name="notification_message_failed_text">Nem sikerült az üzenetetet %s címzettnek elküldeni</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>Rendszer</item>
         <item>Letiltva</item>

--- a/presentation/src/main/res/values-in/strings.xml
+++ b/presentation/src/main/res/values-in/strings.xml
@@ -361,6 +361,9 @@
     </plurals>
     <string name="notification_message_failed_title">Pesan tidak terkirim</string>
     <string name="notification_message_failed_text">Pesan ke %s gagal dikirim</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>Sistem</item>
         <item>Nonaktif</item>

--- a/presentation/src/main/res/values-it/strings.xml
+++ b/presentation/src/main/res/values-it/strings.xml
@@ -366,6 +366,9 @@
     </plurals>
     <string name="notification_message_failed_title">Messaggi non inviati</string>
     <string name="notification_message_failed_text">Il messaggio a %s non è stato inviato</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>Sistema</item>
         <item>Disabilitato</item>

--- a/presentation/src/main/res/values-iw/strings.xml
+++ b/presentation/src/main/res/values-iw/strings.xml
@@ -376,6 +376,9 @@
     </plurals>
     <string name="notification_message_failed_title">הודעה לא נשלחה</string>
     <string name="notification_message_failed_text">שליחת ההודעה אל %s נכשלה</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>מערכת</item>
         <item>מושבת</item>

--- a/presentation/src/main/res/values-ja/strings.xml
+++ b/presentation/src/main/res/values-ja/strings.xml
@@ -361,6 +361,9 @@
     </plurals>
     <string name="notification_message_failed_title">メッセージは送信されませんでした</string>
     <string name="notification_message_failed_text">%s へのメッセージの送信に失敗しました</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>システム</item>
         <item>無効</item>

--- a/presentation/src/main/res/values-ko/strings.xml
+++ b/presentation/src/main/res/values-ko/strings.xml
@@ -363,6 +363,9 @@
     </plurals>
     <string name="notification_message_failed_title">메시지 전송 실패</string>
     <string name="notification_message_failed_text">%s 에게 보낼 메시지 전송이 실패했습니다</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>시스템 설정</item>
         <item>사용 안 함</item>

--- a/presentation/src/main/res/values-lt/strings.xml
+++ b/presentation/src/main/res/values-lt/strings.xml
@@ -376,6 +376,9 @@
     </plurals>
     <string name="notification_message_failed_title">Žinutė neišsiųsta</string>
     <string name="notification_message_failed_text">Žinutę, skirta %s, išsiųsti nepavyko</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>System</item>
         <item>Disabled</item>

--- a/presentation/src/main/res/values-nb/strings.xml
+++ b/presentation/src/main/res/values-nb/strings.xml
@@ -366,6 +366,9 @@
     </plurals>
     <string name="notification_message_failed_title">Meldingen ble ikke sendt</string>
     <string name="notification_message_failed_text">Meldingen til %s kunne ikke sendes</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>System</item>
         <item>Deaktivert</item>

--- a/presentation/src/main/res/values-ne/strings.xml
+++ b/presentation/src/main/res/values-ne/strings.xml
@@ -366,6 +366,9 @@
     </plurals>
     <string name="notification_message_failed_title">Message not sent</string>
     <string name="notification_message_failed_text">The message to %s failed to send</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>System</item>
         <item>Disabled</item>

--- a/presentation/src/main/res/values-night-v27/strings.xml
+++ b/presentation/src/main/res/values-night-v27/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
+</resources>

--- a/presentation/src/main/res/values-night/strings.xml
+++ b/presentation/src/main/res/values-night/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
+</resources>

--- a/presentation/src/main/res/values-nl/strings.xml
+++ b/presentation/src/main/res/values-nl/strings.xml
@@ -366,6 +366,9 @@
     </plurals>
     <string name="notification_message_failed_title">Bericht niet verzonden</string>
     <string name="notification_message_failed_text">Het bericht naar %s is niet verzonden</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>Systeem</item>
         <item>Uitgeschakeld</item>

--- a/presentation/src/main/res/values-pl/strings.xml
+++ b/presentation/src/main/res/values-pl/strings.xml
@@ -383,6 +383,9 @@
     </plurals>
     <string name="notification_message_failed_title">Wiadomość nie została wysłana</string>
     <string name="notification_message_failed_text">Wiadomość %s nie została wysłana</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>Systemowy</item>
         <item>Wyłączony</item>

--- a/presentation/src/main/res/values-pt-rBR/strings.xml
+++ b/presentation/src/main/res/values-pt-rBR/strings.xml
@@ -366,6 +366,9 @@
     </plurals>
     <string name="notification_message_failed_title">Mensagem não enviada</string>
     <string name="notification_message_failed_text">A mensagem para %s falhou ao enviar</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>Sistema</item>
         <item>Desativado</item>

--- a/presentation/src/main/res/values-pt/strings.xml
+++ b/presentation/src/main/res/values-pt/strings.xml
@@ -366,6 +366,9 @@
     </plurals>
     <string name="notification_message_failed_title">Mensagem não enviada</string>
     <string name="notification_message_failed_text">Não foi possível enviar a mensagem para %s</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>Sistema</item>
         <item>Desativado</item>

--- a/presentation/src/main/res/values-ro/strings.xml
+++ b/presentation/src/main/res/values-ro/strings.xml
@@ -371,6 +371,9 @@
     </plurals>
     <string name="notification_message_failed_title">Mesajul nu a fost trimis</string>
     <string name="notification_message_failed_text">Mesajul către %s nu aputut fi trimis</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>Sistem</item>
         <item>Dezactivat</item>

--- a/presentation/src/main/res/values-ru/strings.xml
+++ b/presentation/src/main/res/values-ru/strings.xml
@@ -376,6 +376,9 @@
     </plurals>
     <string name="notification_message_failed_title">Сообщение не отправлено</string>
     <string name="notification_message_failed_text">Не удалось отправить сообщение для %s</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>Как в системе</item>
         <item>Отключено</item>

--- a/presentation/src/main/res/values-sk/strings.xml
+++ b/presentation/src/main/res/values-sk/strings.xml
@@ -376,6 +376,9 @@
     </plurals>
     <string name="notification_message_failed_title">Správa nebola odoslaná</string>
     <string name="notification_message_failed_text">Zlyhalo odoslanie správy pre %s</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>Systém</item>
         <item>Vypnuté</item>

--- a/presentation/src/main/res/values-sl/strings.xml
+++ b/presentation/src/main/res/values-sl/strings.xml
@@ -376,6 +376,9 @@
     </plurals>
     <string name="notification_message_failed_title">Sporočilo ni poslano</string>
     <string name="notification_message_failed_text">Sporočilo za %s ni bilo poslano</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>Sistem</item>
         <item>Onemogočen</item>

--- a/presentation/src/main/res/values-sr/strings.xml
+++ b/presentation/src/main/res/values-sr/strings.xml
@@ -371,6 +371,9 @@
     </plurals>
     <string name="notification_message_failed_title">Порука није послата</string>
     <string name="notification_message_failed_text">Порука за %s није послата</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>Систем</item>
         <item>Онемогућено</item>

--- a/presentation/src/main/res/values-sv/strings.xml
+++ b/presentation/src/main/res/values-sv/strings.xml
@@ -366,6 +366,9 @@
     </plurals>
     <string name="notification_message_failed_title">Meddelandet skickades inte</string>
     <string name="notification_message_failed_text">Meddelandet till %s misslyckades att skicka</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>System</item>
         <item>Inaktiverad</item>

--- a/presentation/src/main/res/values-ta/strings.xml
+++ b/presentation/src/main/res/values-ta/strings.xml
@@ -366,6 +366,9 @@
     </plurals>
     <string name="notification_message_failed_title">தகவல் அனுப்பப்படவில்லை</string>
     <string name="notification_message_failed_text">%s-க்கான குறுந்தகவல் அனுப்ப தோல்வி</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>முறைமை</item>
         <item>முடக்கத்தில்</item>

--- a/presentation/src/main/res/values-th/strings.xml
+++ b/presentation/src/main/res/values-th/strings.xml
@@ -361,6 +361,9 @@
     </plurals>
     <string name="notification_message_failed_title">ข้อความไม่ถูกส่ง</string>
     <string name="notification_message_failed_text">ข้อความที่จะส่งถึง %s ไม่สามารถส่งได้</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>System</item>
         <item>Disabled</item>

--- a/presentation/src/main/res/values-tl/strings.xml
+++ b/presentation/src/main/res/values-tl/strings.xml
@@ -366,6 +366,9 @@
     </plurals>
     <string name="notification_message_failed_title">Message not sent</string>
     <string name="notification_message_failed_text">The message to %s failed to send</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>System</item>
         <item>Disabled</item>

--- a/presentation/src/main/res/values-tr/strings.xml
+++ b/presentation/src/main/res/values-tr/strings.xml
@@ -368,6 +368,9 @@ BAĞLAM İSTEĞİ</string>
     </plurals>
     <string name="notification_message_failed_title">İleti gönderilemedi</string>
     <string name="notification_message_failed_text">%s mesaj gönderilemedi</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>Sistem</item>
         <item>Devre dışı</item>

--- a/presentation/src/main/res/values-uk/strings.xml
+++ b/presentation/src/main/res/values-uk/strings.xml
@@ -376,6 +376,9 @@
     </plurals>
     <string name="notification_message_failed_title">Повідомлення не надіслано</string>
     <string name="notification_message_failed_text">Не вдалося надіслати повідомлення для %s</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>Система</item>
         <item>Вимкнено</item>

--- a/presentation/src/main/res/values-ur/strings.xml
+++ b/presentation/src/main/res/values-ur/strings.xml
@@ -366,6 +366,9 @@
     </plurals>
     <string name="notification_message_failed_title">Message not sent</string>
     <string name="notification_message_failed_text">The message to %s failed to send</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>System</item>
         <item>Disabled</item>

--- a/presentation/src/main/res/values-v27/strings.xml
+++ b/presentation/src/main/res/values-v27/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
+</resources>

--- a/presentation/src/main/res/values-vi/strings.xml
+++ b/presentation/src/main/res/values-vi/strings.xml
@@ -361,6 +361,9 @@
     </plurals>
     <string name="notification_message_failed_title">Các tin không gửi</string>
     <string name="notification_message_failed_text">Các tin gửi đến %s không thành công</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>Theo hệ thống</item>
         <item>Vô hiệu hoá</item>

--- a/presentation/src/main/res/values-zh-rCN/strings.xml
+++ b/presentation/src/main/res/values-zh-rCN/strings.xml
@@ -361,6 +361,9 @@
     </plurals>
     <string name="notification_message_failed_title">消息未发送</string>
     <string name="notification_message_failed_text">给%s的短信发送失败</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>系统</item>
         <item>已禁用</item>

--- a/presentation/src/main/res/values-zh-rHK/strings.xml
+++ b/presentation/src/main/res/values-zh-rHK/strings.xml
@@ -361,6 +361,9 @@
     </plurals>
     <string name="notification_message_failed_title">消息未發送</string>
     <string name="notification_message_failed_text">給%s的訊息發送失敗</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>跟隨系統</item>
         <item>停用</item>

--- a/presentation/src/main/res/values-zh-rTW/strings.xml
+++ b/presentation/src/main/res/values-zh-rTW/strings.xml
@@ -364,6 +364,9 @@
     </plurals>
     <string name="notification_message_failed_title">訊息未傳送</string>
     <string name="notification_message_failed_text">給 %s 的訊息傳送失敗</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
     <string-array name="night_modes">
         <item>跟隨系統</item>
         <item>停用</item>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -17,8 +17,7 @@
   ~ along with QKSMS.  If not, see <http://www.gnu.org/licenses/>.
   -->
 <resources>
-
-    <string name="app_name" translatable="false">QUIK</string>
+    <string name="app_name" translatable="false">Messages</string>
 
     <string name="shortcut_compose_long_label">New conversation</string>
     <string name="shortcut_compose_short_label">Compose</string>
@@ -63,12 +62,12 @@
     <string name="archived_empty_text">Your archived conversations will appear here</string>
     <string name="main_fab_cd">Start new conversation</string>
     <string name="main_default_sms_title">Love texting again</string>
-    <string name="main_default_sms_message">Make QUIK your default SMS app</string>
+    <string name="main_default_sms_message">Make UP Messages your default SMS app</string>
     <string name="main_default_sms_change">Change</string>
     <string name="main_permission_required">Permission required</string>
-    <string name="main_permission_sms">QUIK needs permission to send and view SMS messages</string>
-    <string name="main_permission_contacts">QUIK needs permission to view your contacts</string>
-    <string name="main_permission_notifications">QUIK needs permission to display notifications</string>
+    <string name="main_permission_sms">UP Messages needs permission to send and view SMS messages</string>
+    <string name="main_permission_contacts">UP Messages needs permission to view your contacts</string>
+    <string name="main_permission_notifications">UP Messages needs permission to display notifications</string>
     <string name="main_permission_allow">Allow</string>
 
     <string name="drawer_inbox">Inbox</string>
@@ -83,7 +82,7 @@
     <string name="drawer_plus_banner_title" translatable="false">DEPRECATED - drawer_plus_banner_title</string>
     <string name="drawer_plus_banner_summary">Unlock amazing new features, and support development</string>
 
-    <string name="rate_title">Enjoying QUIK?</string>
+    <string name="rate_title">Enjoying UP Messages?</string>
     <string name="rate_summary">Share some love and rate us on Google Play!</string>
     <string name="rate_okay">OKAY!</string>
     <string name="rate_dismiss">DISMISS</string>
@@ -187,7 +186,7 @@
     <string name="backup_selected_backup_error_message">Couldn\'t read backup file</string>
     <string name="backup_selected_backup_details_title">Backup details</string>
     <string name="backup_restore_dialog_title">Backups</string>
-    <string name="backup_restore_dialog_summary" translatable="false">/QUIK/Backups</string>
+    <string name="backup_restore_dialog_summary" translatable="false">/UP-Messages/Backups</string>
     <string name="backup_restore_dialog_empty">No backups found</string>
     <string name="backup_disclaimer">Currently, only SMS is supported by Backup and Restore. MMS support and scheduled backups will be coming soon!</string>
     <string name="backup_now">Backup now</string>
@@ -280,7 +279,7 @@
     <string name="settings_mms_size_title">Auto-compress MMS attachments</string>
     <string name="settings_sync_title">Sync messages</string>
     <string name="settings_sync_summary">Re-sync your messages with the native Android SMS database</string>
-    <string name="settings_about_title">About QUIK</string>
+    <string name="settings_about_title">About UP Messages</string>
     <string name="settings_version">Version %s</string>
     <string name="settings_logging_enabled">Debug logging enabled</string>
     <string name="settings_logging_disabled">Debug logging disabled</string>
@@ -293,8 +292,8 @@
     <string name="blocking_conversations">Blocked conversations</string>
 
     <string name="blocking_manager_title">Blocking Manager</string>
-    <string name="blocking_manager_qksms_title">QUIK</string>
-    <string name="blocking_manager_qksms_summary">Built-in blocking functionality in QUIK</string>
+    <string name="blocking_manager_qksms_title">UP Messages</string>
+    <string name="blocking_manager_qksms_summary">Built-in blocking functionality in UP Messages</string>
     <string name="blocking_manager_call_blocker_title" translatable="false">Call Blocker - Incoming/Outgoing</string>
     <string name="blocking_manager_call_blocker_summary">Block spam messages, numbers &amp; unknown calls with blacklist &amp; Schedule</string>
     <string name="blocking_manager_call_control_title" translatable="false">Call Control</string>
@@ -343,7 +342,7 @@
     <string name="qksms_plus_upgrade_d" translatable="false">One-time purchase of %1$s %2$s</string>
     <!-- Substitutions are for price and currency. Ex: Unlock + donate for $4.99 USD -->
     <string name="qksms_plus_upgrade_donate">Unlock + donate for %1$s %2$s</string>
-    <string name="qksms_plus_thanks_title">Thank you for supporting QUIK!</string>
+    <string name="qksms_plus_thanks_title">Thank you for supporting UP Messages!</string>
     <string name="qksms_plus_thanks_summary">You now have access to all QUIK+ features</string>
     <string name="qksms_plus_error">An error has occurred, please try again</string>
     <string name="qksms_plus_free_title">QUIK+ is free for F-Droid users! If you\'d like to support development, a donation would be highly appreciated.</string>
@@ -392,7 +391,7 @@
     <string name="about_license" translatable="false">GNU General Public License v3.0</string>
     <string name="about_copyright" translatable="false">© 2014–2024</string>
 
-    <string name="changelog_title" translatable="false">New in QUIK</string>
+    <string name="changelog_title" translatable="false">New in UP Messages</string>
     <string name="changelog_version" translatable="false">Version %s</string>
     <string name="changelog_added" translatable="false">Added</string>
     <string name="changelog_improved" translatable="false">Improved</string>
@@ -431,6 +430,9 @@
     </plurals>
     <string name="notification_message_failed_title">Message not sent</string>
     <string name="notification_message_failed_text">The message to %s failed to send</string>
+    <string name="open_source_credit_title">Open Source Credit</string>
+    <string name="up_open_source_link_title">Unplugged Source Code</string>
+    <string name="up_open_source_link">https://github.com/werunplugged/up_sms</string>
 
     <string-array name="night_modes">
         <item>System</item>


### PR DESCRIPTION
Changing everything related to Quik to UP etc, setting the default app accent color to out primary color, changing the about page to have our details and the open source's developer details in an expending view, setting default font, changing package id, fix crash in the blocked numbers page, removing signing from the build.gradle for now, adding deprecation notices in some places so the build will not fail, removing everything that's related to the Quik+ subscription model since we don't need it, removing some stuff from the drawer view (settings for Quik+, alerts etc), setting default swipes on SMS to be archive and delete, changing app name from Quik to Messages.