### PR TITLE
Removing the storage permission check for the camera intent since we …

### DIFF
--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeViewModel.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeViewModel.kt
@@ -495,13 +495,8 @@ class ComposeViewModel @Inject constructor(
         view.cameraIntent
                 .autoDisposable(view.scope())
                 .subscribe {
-                    if (permissionManager.hasStorage()) {
-                        newState { copy(attaching = false) }
-                        view.requestCamera()
-                    } else {
-                        view.requestStoragePermission()
-                    }
-                }
+                    newState { copy(attaching = false) }
+                    view.requestCamera() }
 
         // Attach a photo from gallery
         view.galleryIntent


### PR DESCRIPTION
Removing the storage permission check for the camera intent since we don't need storage access in order to launch the camera and attach photos and videos taken from there. With this permission check the camera button doesn't do anything. In addition, from Android 12 this storage permission is deprecated so it's irrelevant.