### PR TITLE
Fix for 2 issues:

### DIFF
--- a/android-smsmms/src/main/java/com/klinker/android/send_message/StripAccents.java
+++ b/android-smsmms/src/main/java/com/klinker/android/send_message/StripAccents.java
@@ -16,33 +16,11 @@
 
 package com.klinker.android.send_message;
 
-import android.telephony.SmsMessage;
+import java.text.Normalizer;
 
 public class StripAccents {
-
-    public static String characters = "\u03B1\u03B2\u03B3\u03B4\u03B5\u03B6\u03B7\u03B8\u03B9\u03BA\u03BB\u03BC\u03BD" +
-            "\u03BE\u03BF\u03C0\u03C1\u03C3\u03C2\u03C4\u03C5\u03C6\u03C7\u03C8\u03C9\u03AC\u03AD" +
-            "\u03AE\u03AF\u03CC\u03CD\u03CE\u03CA\u03CB\u0390\u03B0\u0391\u0392\u0395\u0396\u0397\u0399" +
-            "\u039A\u039C\u039D\u039F\u03A1\u03A4\u03A5\u03A7\u0386\u0388\u0389\u038A\u038C\u038F\u03AA" +
-            "\u03AB\u0170\u0171\u0150\u0151\u0105\u0107\u0119\u0142\u0144\u015B\u017A\u017C\u0104\u0106" +
-            "\u0118\u0141\u0143\u015A\u0179\u017B\u00C0\u00C2\u00C3\u00C8\u00CA\u00CC\u00CE\u00D2\u00D5" +
-            "\u00D9\u00DB\u00E2\u00E3\u00EA\u00EE\u00F5\u00FA\u00FB\u00E7\u011B\u0161\u010D\u0159\u017E\u010F" +
-            "\u0165\u0148\u00E1\u00ED\u00E9\u00F3\u00FD\u016F\u011A\u0160\u010C\u0158\u017D\u010E\u0164\u0147" +
-            "\u00C1\u00C9\u00CD\u00D3\u00DD\u00DA\u016E\u0155\u013A\u013E\u00F4\u0154\u0139\u013D\u00D4\u00CF\u00EF\u00EB\u00CB";
-
-    public static String gsm = "AB\u0393\u0394EZH\u0398IK\u039BMN\u039EO\u03A0P\u03A3\u03A3TY\u03A6X\u03A8\u03A9AEHIOY" +
-            "\u03A9IYIYABEZHIKMNOPTYXAEHIO\u03A9IY\u00DC\u00FC\u00D6\u00F6acelnszzACELNSZZAAAEEIIOOUU" +
-            "aaeiouucescrzdtnaieoyuESCRZDTNAEIOYUUrlloRLLOIIee";
-
     public static String stripAccents(String s) {
-        int[] messageData = SmsMessage.calculateLength(s, false);
-
-        if (messageData[0] != 1) {
-            for (int i = 0; i < characters.length(); i++) {
-                s = s.replaceAll(characters.substring(i, i + 1), gsm.substring(i, i + 1));
-            }
-        }
-
-        return s;
+        return Normalizer.normalize(s, Normalizer.Form.NFD)
+                .replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
     }
 }

--- a/presentation/src/main/java/com/moez/QKSMS/common/util/NotificationManagerImpl.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/util/NotificationManagerImpl.kt
@@ -150,7 +150,10 @@ class NotificationManagerImpl @Inject constructor(
                 .setVibrate(if (prefs.vibration(threadId).get()) VIBRATE_PATTERN else longArrayOf(0))
 
         // Tell the notification if it's a group message
-        val messagingStyle = NotificationCompat.MessagingStyle("Me")
+        val sender = Person.Builder()
+            .setName("Me")
+            .build()
+        val messagingStyle = NotificationCompat.MessagingStyle(sender)
         if (conversation.recipients.size >= 2) {
             messagingStyle.isGroupConversation = true
             messagingStyle.conversationTitle = conversation.getTitle()
@@ -316,7 +319,7 @@ class NotificationManagerImpl @Inject constructor(
             context.getSystemService<PowerManager>()?.let { powerManager ->
                 if (!powerManager.isInteractive) {
                     val flags = PowerManager.SCREEN_DIM_WAKE_LOCK or PowerManager.ACQUIRE_CAUSES_WAKEUP
-                    val wakeLock = powerManager.newWakeLock(flags, context.packageName)
+                    val wakeLock = powerManager.newWakeLock(flags, "${context.packageName}:WakeScreen")
                     wakeLock.acquire(5000)
                 }
             }


### PR DESCRIPTION
Fix for 2 issues:
1. Removing accents in outgoing SMS wasn't working - fixed by replacing the old method (which was created manually 11 years ago) with the new(ish) Java built-in way to normalize text.
2. Fix for wake lock disable not working—when choosing not to wake the screen by incoming text, the screen was still waking up. Fixed by adding the missing part of the API for the wakeLock.